### PR TITLE
Testing docker image tag process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,6 @@ RUN apt-get update && apt-get install -y \
 	    screen \
 	    tmux \
 	    zsh \
-            open \
 	    xfsprogs \
 	    libffi-dev \
 	    python-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y \
 	    screen \
 	    tmux \
 	    zsh \
+            open \
 	    xfsprogs \
 	    libffi-dev \
 	    python-dev \

--- a/local-docker-compose.yml
+++ b/local-docker-compose.yml
@@ -3,8 +3,6 @@ services:
   insurance_env:
     # default
     image: kwhadocker/insurance-requirements:latest
-    # to test
-    # image: insurance-requirements-test
     environment:
       - USER
       - POSTGRES_USER=root


### PR DESCRIPTION
Added a line to install the `open` package to `insurance-requirements` to test if DockerHub will auto-build `insurance-requirements:v0`