### PR TITLE
Use v2 of ubuntu18-postgres11 to get UTF8 fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kwhadocker/ubuntu18-postgres11:latest
+FROM kwhadocker/ubuntu18-postgres11:v2
 
 # Move to root
 WORKDIR /root/


### PR DESCRIPTION
This makes it so postgres databases inside the container are created with UTF8 encoding instead of SQL_ASCII by default.

This image was successfully built https://hub.docker.com/repository/registry-1.docker.io/kwhadocker/insurance-requirements/builds/763fe19d-5db9-49f3-b155-75f43c31759a

This PR is to merge it into master as well.